### PR TITLE
Add a few microoptimizations to the generation code

### DIFF
--- a/src/main/java/com/kuba6000/mobsinfo/api/utils/ItemID.java
+++ b/src/main/java/com/kuba6000/mobsinfo/api/utils/ItemID.java
@@ -35,6 +35,7 @@ public class ItemID {
     private final boolean ignorecount;
     private final boolean ignoremeta;
     private final boolean ignorenbt;
+    private int cachedHashCode = 0;
 
     public static ItemID create(ItemStack stack) {
         return new ItemID(stack, true, true, true, true); // ignore count by default
@@ -80,14 +81,26 @@ public class ItemID {
 
     @Override
     public int hashCode() {
-        return Objects.hash(item, count, meta, tag);
+        int code = cachedHashCode;
+        if (code == 0) {
+            code = Objects.hash(item, count, meta, tag);
+            if (code == 0) {
+                code = 1;
+            }
+            cachedHashCode = code;
+        }
+        return code;
     }
 
     @Override
     public boolean equals(Object obj) {
         if (obj == null) return false;
         if (obj == this) return true;
-        if (obj instanceof ItemID) return obj.hashCode() == this.hashCode();
+        if (obj instanceof ItemID other) {
+            return this.item == other.item && this.count == other.count
+                && this.meta == other.meta
+                && Objects.equals(this.tag, other.tag);
+        }
         if (obj instanceof ItemStack) {
             if (!item.equals(((ItemStack) obj).getItem())) return false;
             if (!ignorecount) if (count != ((ItemStack) obj).stackSize) return false;

--- a/src/main/java/com/kuba6000/mobsinfo/loader/VillagerTradesLoader.java
+++ b/src/main/java/com/kuba6000/mobsinfo/loader/VillagerTradesLoader.java
@@ -47,6 +47,9 @@ public class VillagerTradesLoader {
 
         if (!Config.VillagerTradesHandler.enabled) return;
 
+        LOG.info("Generating Recipe Map for Villager Trades Helper");
+        final long startTime = System.currentTimeMillis();
+
         DummyWorld world = new DummyWorld();
 
         RandomSequencer frand = new RandomSequencer();
@@ -276,6 +279,9 @@ public class VillagerTradesLoader {
         }
         MobRecipeLoader.isInGenerationProcess = false;
 
+        final long endTime = System.currentTimeMillis();
+        LOG.info("Villager trade information generation took {} ms", endTime - startTime);
+
     }
 
     public static void processVillagerTrades() {
@@ -336,9 +342,8 @@ public class VillagerTradesLoader {
                     ItemID.createNoCopy(recipe.getItemToBuy()),
                     recipe.hasSecondItemToBuy() ? ItemID.createNoCopy(recipe.getSecondItemToBuy()) : null),
                 ItemID.createNoCopy(recipe.getItemToSell()));
-            TradeInstance instance;
-            if (itemsToTrade.containsKey(key)) {
-                instance = itemsToTrade.get(key);
+            TradeInstance instance = itemsToTrade.get(key);
+            if (instance != null) {
                 instance.update(recipe);
                 instance.chance += chance;
             } else {


### PR DESCRIPTION
- Replace two map lookups with one in the villager trade implementation
- Cache the hashCode of ItemIDs to avoid repeatedly calling into the somewhat slow Objects.hashCode
- Use actual equality comparisons instead of hashCode calculations for equals(), comparing on average 3 pointers that are next to each other in memory will be faster than computing hashCodes

Before (in an empty devenv, gains in a real environment should be higher):
```
Recipe map generated! Mapped 30 entities! It took 724ms
Villager trade information generation took 5 ms
```

After:
```
Recipe map generated! Mapped 30 entities! It took 573ms
Villager trade information generation took 4 ms
```